### PR TITLE
신고 뷰 레이아웃 구현

### DIFF
--- a/Beaver.xcodeproj/xcuserdata/jangjia01234.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Beaver.xcodeproj/xcuserdata/jangjia01234.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,7 +7,7 @@
 		<key>Beaver.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>0</integer>
 		</dict>
 		<key>Promises (Playground) 1.xcscheme</key>
 		<dict>

--- a/Beaver/Scenes/Report/ReportView.swift
+++ b/Beaver/Scenes/Report/ReportView.swift
@@ -6,13 +6,115 @@
 //
 
 import SwiftUI
+import MapKit
 
 struct ReportView: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var centerCoordinate: CLLocationCoordinate2D = .init()
+    @State private var position: MapCameraPosition
+    @State private var showingReportSheet = false
+    @Binding var coordinates: Coordinates?
+    
+    init(coordinates: Binding<Coordinates?>) {
+        if let coordinates = coordinates.wrappedValue {
+            self.position = .camera(.init(centerCoordinate: .init(coordinates), distance: 1000))
+        } else {
+            let rect = MKMapRect(origin: .init(.hico), size: .init(width: 2000, height: 2000))
+            let region = MKCoordinateRegion(rect)
+            self.position = .region(region)
+        }
+        
+        self._coordinates = coordinates
+    }
+    
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        NavigationStack {
+            ZStack {
+                Map(position: $position)
+                    .onMapCameraChange { context in
+                        centerCoordinate = context.camera.centerCoordinate
+                    }
+                
+                Image(systemName: "mappin.and.ellipse")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 50, height: 50)
+
+                bottomSubmitButton
+                    .padding(.bottom, 250)
+            }
+            .navigationTitle(Text("Report potholes"))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Image(systemName: "chevron.left")
+                }
+            }
+            .onAppear {
+                showingReportSheet = true
+            }
+            .sheet(isPresented: $showingReportSheet) {
+                Text("Perceived Risk of Pothole")
+                    .presentationDetents([
+                        .custom(TinyDetent.self),
+                        .medium
+                    ])
+            }
+        }
     }
 }
 
+struct TinyDetent: CustomPresentationDetent {
+    static func height(in context: Context) -> CGFloat? {
+        if context.dynamicTypeSize.isAccessibilitySize {
+            return 140
+        } else {
+            return 220
+        }
+    }
+}
+
+
+private extension ReportView {
+    var bottomSubmitButton: some View {
+        VStack {
+            Spacer()
+            Button("Select the location") {
+                coordinates = .init(
+                    latitude: centerCoordinate.latitude,
+                    longitude: centerCoordinate.longitude
+                )
+                
+                dismiss()
+            }
+            .frame(maxWidth: .infinity, maxHeight: 48)
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+            .bold()
+            .zIndex(2)
+        }
+        .padding(.horizontal)
+    }
+}
+
+struct Coordinates: Codable {
+    let latitude: Double
+    let longitude: Double
+}
+
+extension CLLocationCoordinate2D {
+    init(_ coordinates: Coordinates) {
+        self.init(
+            latitude: coordinates.latitude,
+            longitude: coordinates.longitude
+        )
+    }
+    
+    static let hico = CLLocationCoordinate2D(
+        latitude: 35.83862279759551,
+        longitude: 129.2879123861327
+    )
+}
+
 #Preview {
-    ReportView()
+    ReportView(coordinates: .constant(Coordinates(latitude: 0, longitude: 0)))
 }

--- a/Beaver/Scenes/Report/ReportView.swift
+++ b/Beaver/Scenes/Report/ReportView.swift
@@ -13,6 +13,9 @@ struct ReportView: View {
     @State private var centerCoordinate: CLLocationCoordinate2D = .init()
     @State private var position: MapCameraPosition
     @State private var showingReportSheet = false
+    @State private var showingAlert = false
+    @State private var selectedDangerLevel = 0
+    @State private var isAbleClosed = false
     @Binding var coordinates: Coordinates?
     
     init(coordinates: Binding<Coordinates?>) {
@@ -39,7 +42,7 @@ struct ReportView: View {
                     .resizable()
                     .aspectRatio(contentMode: .fit)
                     .frame(width: 50, height: 50)
-
+                
                 bottomSubmitButton
                     .padding(.bottom, 250)
             }
@@ -54,11 +57,45 @@ struct ReportView: View {
                 showingReportSheet = true
             }
             .sheet(isPresented: $showingReportSheet) {
-                Text("Perceived Risk of Pothole")
-                    .presentationDetents([
-                        .custom(TinyDetent.self),
-                        .medium
-                    ])
+                VStack(alignment: .leading) {
+                    Text("Perceived Risk of Pothole")
+                        .padding(.vertical, 15)
+                        .bold()
+                    
+                    Picker("위험 수준", selection: $selectedDangerLevel) {
+                        Text("\(DangerLevel.low)").tag(0)
+                        Text("\(DangerLevel.medium)").tag(1)
+                        Text("\(DangerLevel.high)").tag(2)
+                    }
+                    .pickerStyle(.segmented)
+                    
+                    Spacer()
+                    
+                    Button(action: {
+                        // TODO: saveDangerLevel()
+                    }) {
+                        HStack {
+                            Spacer()
+                            Text("Submit")
+                            Spacer()
+                        }
+                    }
+                    .foregroundColor(.white)
+                    .padding(10)
+                    .background(Color.accentColor)
+                    .cornerRadius(8)
+                    .alert(isPresented: $showingAlert) {
+                        Alert(title: Text("Form submitted!"),
+                              message: Text("Try another thing"),
+                              dismissButton: .default(Text("Done")))
+                    }
+                }
+                .interactiveDismissDisabled(!isAbleClosed)
+                .presentationDetents([
+                    .custom(TinyDetent.self),
+                    .medium
+                ])
+                .padding(20)
             }
         }
     }
@@ -69,7 +106,7 @@ struct TinyDetent: CustomPresentationDetent {
         if context.dynamicTypeSize.isAccessibilitySize {
             return 140
         } else {
-            return 220
+            return 200
         }
     }
 }


### PR DESCRIPTION
# 이슈

# 체크리스트
- [x] 전체 레이아웃 구성
- [x] 배경에 지도 띄우기
- [x] 하단 시트에 Form 구성
- [x] 시트 작게 뜨고, 처음부터 떠 있고, 닫히지 않도록 커스텀 

# 고민한 내용
- 시트를 커스텀하는 데 신경썼습니다.
- 마커 모양, 컬러 등 디테일한 부분은 추후에 차차 잡을 계획입니다.

# 스크린샷 (선택)
<img width="269" alt="스크린샷 2024-08-11 오전 6 12 42" src="https://github.com/user-attachments/assets/1c652026-5b91-4680-8aed-34e73a269536">

